### PR TITLE
SBTWO-9429-again Extended aria-current to month and year

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -422,4 +422,9 @@ a.datepicker-button.bootstrap:focus {
 	padding: 0.3em 0.6em;
 	display: none;
 }
+
+.datepicker-calendar td[aria-current] {
+	font-weight: bold;
+	font-size: 110%;
+}
  

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -942,6 +942,7 @@
 	 *
 	 */
 	Datepicker.prototype.populateMonthsCalendar = function() {
+		const today = new Date();
 		this.log('populateMonthsCalendar');
 		this.$calendar.find('.datepicker-bn-prev-label').html(this.options.prevMonthButtonLabel);
 		this.$calendar.find('.datepicker-bn-next-label').html(this.options.nextMonthButtonLabel);
@@ -994,6 +995,9 @@
 			gridCells += ' data-value="' + curMonth + '"';
 			gridCells += ' title="' + this.locales.month_names[curMonth] + ' ' + this.year + '"';
 			gridCells += ' aria-label="' + this.locales.month_names[curMonth] + ' ' + this.year + '"';
+			if (curMonth === today.getMonth() && this.curYear === today.getFullYear()) {
+				gridCells += ' aria-current="true"'
+			}
 			gridCells += ' role="gridcell" tabindex="-1" aria-selected="false">' + this.locales.month_names_abbreviated[curMonth];
 			gridCells +=  '</td>';
 			if (curMonth == 3 || curMonth == 7) {
@@ -1014,6 +1018,7 @@
 	 *
 	 */
 	Datepicker.prototype.populateYearsCalendar = function() {
+		const thisYear = new Date().getFullYear();
 		this.$calendar.find('.datepicker-bn-prev-label').html(this.options.prevYearButtonLabel);
 		this.$calendar.find('.datepicker-bn-next-label').html(this.options.nextYearButtonLabel);
 		this.hideObject(this.$fastprev);
@@ -1062,6 +1067,9 @@
 			}
 			gridCells += ' data-value="' + curYear + '"';
 			gridCells += ' title="' + curYear + '"';
+			if (curYear === thisYear) {
+				gridCells += ' aria-current="true"';
+			}
 			gridCells += ' role="gridcell" tabindex="-1" aria-selected="false">' + curYear;
 			gridCells +=  '</td>';
 			var curPos = curYear - startYear;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/ab-datepicker",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "An accessible and bootstrap compatible datepicker",
   "main": "js/datepicker.js",
   "directories": {


### PR DESCRIPTION
Extended the aria-current stuff to apply to month and year, but not time - too much chance of us talking rubbish there depending on where and how it's used.

Added a bit of styling so we have a visual indication of currentness as well. Agreed with Mat that it all looks about as meaningful as Google have made theirs.